### PR TITLE
Change search pages from 30 to 36 results

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -5,7 +5,7 @@ class SearchController < ApplicationController
   def search
     paginate = {
       page: [params[:page].to_i, 1].max,
-      per_page: 30
+      per_page: 36
     }
 
     case params[:type]


### PR DESCRIPTION
Search pages can display anywhere from 1-4 images across. This changes the search page so that it displays 36 results – 36 being a common multiple of 1, 2, 3, and 4. As a result, you don't have a page with 4 across that is only half-filled on the bottom row.

Note that if 36 is too many, 24 is another common multiple than is aesthetically pleasing. I generally prefer more, of course.  :)